### PR TITLE
Add copyparty

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,6 +104,7 @@ Any contributions you make are **greatly appreciated**, please refer to the [con
 
 ### Cloud
 - [Aruba](https://www.aruba.it) 🇮🇹 - Cloud hosting and data center services.
+- [copyparty](https://github.com/9001/copyparty) 🇳🇴 - Self-hosted file-sharing and file-transfer server.
 - [Cozy](https://www.cozy.io) 🇫🇷 - Privacy-first personal cloud for data management.
 - [datacrunch](https://datacrunch.io/) 🇫🇮 - GPU cloud computing for AI/ML workloads.
 - [Elastx](https://www.elastx.se) 🇸🇪 - Managed cloud hosting with a focus on sustainability.


### PR DESCRIPTION
Hello again! We briefly spoke on reddit I believe :>

[copyparty](https://github.com/9001/copyparty) is a self-hosted file-server / file-sharing / file-transfer server.

It's a faster, more lightweight alternative to nextcloud, and it specializes in accepting file uploads at the highest speed possible (by sending multiple chunks in parallel), but also safely (integrity-checked) and robustly (autoresume, and resume after an os-crash on the client or server).

v1.16.14 added an option to forget uploader-IP after a given time, so it *should* be [GDPR compliant](https://github.com/9001/copyparty#gdpr-compliance) now :>