### PR TITLE
Update URL and name for Supertext

### DIFF
--- a/README.md
+++ b/README.md
@@ -331,7 +331,7 @@ Any contributions you make are **greatly appreciated**, please refer to the [con
 - [ModernMT](https://www.modernmt.com) 🇮🇹 - Adaptive machine translation for enterprises.
 - [Reverso](https://www.reverso.net) 🇫🇷 - Context-aware translation and language tools.
 - [SimpleLocalize](https://simplelocalize.io) 🇵🇱 - Translation management for software projects.
-- [Textshuttle](https://www.textshuttle.ai) 🇨🇭 - AI-driven translation for businesses.
+- [Supertext](https://www.supertext.com) (formerly TextShuttle) 🇨🇭 - AI-driven translation for businesses.
 - [Unbabel](https://unbabel.com/) 🇵🇹
 - [Widn.ai](https://www.widn.ai/) 🇵🇹
 


### PR DESCRIPTION
I was looking through the list and noticed that link has an expired certificate and the website has been moved to https://www.supertext.com instead. 

Also, thanks for the awesome work!