### PR TITLE
Goose VPN, removed WWW

### DIFF
--- a/README.md
+++ b/README.md
@@ -440,7 +440,7 @@ Any contributions you make are **greatly appreciated**, please refer to the [con
 ### VPN
 - [AirVPN](https://www.airvpn.org) 🇮🇹 - Privacy-focused VPN with open-source ethos.
 - [F‑Secure FREEDOME VPN](https://www.f-secure.com) 🇫🇮 - VPN with malware blocking.
-- [GOOSE VPN](https://www.goosevpn.com) 🇳🇱 - Dutch VPN provider with no-log policy.
+- [GOOSE VPN](https://goosevpn.com) 🇳🇱 - Dutch VPN provider with no-log policy.
 - [IVPN](https://www.ivpn.net/en/) 🇬🇧
 - [Mullvad VPN](https://www.mullvad.net) 🇸🇪 - No-logs VPN with anonymous accounts.
 - [NordVPN](https://nordvpn.com/) 🇱🇹


### PR DESCRIPTION
Seem like GooseVPN returns 500 on the old URL, removed WWW and it seem to work.